### PR TITLE
feat: Add GitHub Actions workflow for building releases

### DIFF
--- a/.github/workflows/build_release.yml
+++ b/.github/workflows/build_release.yml
@@ -1,0 +1,38 @@
+name: Build and Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: windows-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.11' # Using a common stable version
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+
+    - name: Build with PyInstaller
+      run: |
+        pyinstaller --name "FulfillmentCalculator" --onefile --windowed main_app.py
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ github.event.release.upload_url }}
+        asset_path: ./dist/FulfillmentCalculator.exe
+        asset_name: FulfillmentCalculator-v${{ github.ref_name }}.exe
+        asset_content_type: application/vnd.microsoft.portable-executable

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 pandas
 PySide6
+pyinstaller


### PR DESCRIPTION
This commit adds a GitHub Actions workflow file (`build_release.yml`) to automate the process of creating a distributable executable.

- The workflow triggers on new tags (e.g., 'v1.0').
- It runs on a Windows environment.
- It uses PyInstaller to package the application into a single `.exe` file.
- The resulting executable is uploaded as a release asset.

`pyinstaller` has also been added to `requirements.txt`.