### PR TITLE
fix: Implement robust timezone-aware date filtering

### DIFF
--- a/calculator_logic.py
+++ b/calculator_logic.py
@@ -20,17 +20,17 @@ def calculate_costs(filepath, first_sku_cost, next_sku_cost, unit_cost, start_da
         # Handle date filtering
         if start_date_str and end_date_str:
             fulfilled_df['Fulfilled at'] = pd.to_datetime(fulfilled_df['Fulfilled at'], errors='coerce')
-            fulfilled_df = fulfilled_df.dropna(subset=['Fulfilled at'])  # Drop rows where date conversion failed
+            fulfilled_df = fulfilled_df.dropna(subset=['Fulfilled at'])
 
-            # Make the 'Fulfilled at' column timezone-naive to prevent comparison errors
-            if pd.api.types.is_datetime64_any_dtype(fulfilled_df['Fulfilled at']) and fulfilled_df['Fulfilled at'].dt.tz is not None:
-                fulfilled_df['Fulfilled at'] = fulfilled_df['Fulfilled at'].dt.tz_localize(None)
+            # Convert user-selected dates to pandas Timestamps
+            start_date = pd.Timestamp(start_date_str)
+            end_date = pd.Timestamp(end_date_str).replace(hour=23, minute=59, second=59)
 
-            start_date = datetime.strptime(start_date_str, '%Y-%m-%d')
-            end_date = datetime.strptime(end_date_str, '%Y-%m-%d')
-
-            # Add time to end_date to make the range inclusive of the whole day
-            end_date = end_date.replace(hour=23, minute=59, second=59)
+            # If the source data is timezone-aware, make the user's dates aware too
+            source_tz = fulfilled_df['Fulfilled at'].dt.tz
+            if source_tz:
+                start_date = start_date.tz_localize(source_tz)
+                end_date = end_date.tz_localize(source_tz)
 
             fulfilled_df = fulfilled_df[(fulfilled_df['Fulfilled at'] >= start_date) & (fulfilled_df['Fulfilled at'] <= end_date)]
 


### PR DESCRIPTION
This commit provides a more robust solution to the `TypeError` that occurred when comparing offset-naive and offset-aware datetime objects.

The previous fix was not sufficient. This new implementation respects the timezone information present in the source CSV file. It detects the timezone of the 'Fulfilled at' column and applies the same timezone to the user-selected start and end dates before performing the comparison. This ensures that the filtering logic works correctly regardless of whether the source data is timezone-aware or naive.